### PR TITLE
Corrections in step3.md

### DIFF
--- a/course-content/step3.md
+++ b/course-content/step3.md
@@ -200,7 +200,7 @@ SELECT
   -- need to cast approx. floats to exact numeric types for round!
   ROUND(AVG(price)::NUMERIC, 2) AS average_eth_price
 FROM trading.prices
-WHERE EXTRACT(YEAR FROM market_date) = 2020
+WHERE EXTRACT(YEAR FROM market_date) = 2020 AND ticker = 'ETH'
 GROUP BY month_start
 ORDER BY month_start;
 ```
@@ -210,18 +210,19 @@ ORDER BY month_start;
 
 |      month_start       | average_eth_price |
 | ---------------------- | ----------------- |
-| 2020-01-01 00:00:00+00 |           4267.73 |
-| 2020-02-01 00:00:00+00 |           4937.66 |
-| 2020-03-01 00:00:00+00 |           3511.64 |
-| 2020-04-01 00:00:00+00 |           3691.16 |
-| 2020-05-01 00:00:00+00 |           4730.50 |
-| 2020-06-01 00:00:00+00 |           4858.88 |
-| 2020-07-01 00:00:00+00 |           4925.83 |
-| 2020-08-01 00:00:00+00 |           6020.07 |
-| 2020-09-01 00:00:00+00 |           5505.55 |
-| 2020-10-01 00:00:00+00 |           6132.07 |
-| 2020-11-01 00:00:00+00 |           8573.75 |
-| 2020-12-01 00:00:00+00 |          11302.20 |
+| 2020-01-01 00:00:00+00 |          156.65   |
+| 2020-02-01 00:00:00+00 |          238.76   |
+| 2020-03-01 00:00:00+00 |          160.18   |
+| 2020-04-01 00:00:00+00 |          171.29   |
+| 2020-05-01 00:00:00+00 |          207.45   |
+| 2020-06-01 00:00:00+00 |          235.92   |
+| 2020-07-01 00:00:00+00 |          259.57   |
+| 2020-08-01 00:00:00+00 |          401.73   |
+| 2020-09-01 00:00:00+00 |          367.77   |
+| 2020-10-01 00:00:00+00 |          375.79   |
+| 2020-11-01 00:00:00+00 |          486.73   |
+| 2020-12-01 00:00:00+00 |          622.35   |
+
 <br>
 
 ### Question 7
@@ -454,8 +455,8 @@ This is a super common error found in SQL queries and we usually recommend casti
 ```sql
 SELECT
   ticker,
-  SUM(CASE WHEN price > open THEN 1 ELSE 0 END) / COUNT(*)) AS breakout_percentage,
-  SUM(CASE WHEN price < open THEN 1 ELSE 0 END) / COUNT(*)) AS non_breakout_percentage
+  SUM(CASE WHEN price > open THEN 1 ELSE 0 END) / COUNT(*) AS breakout_percentage,
+  SUM(CASE WHEN price < open THEN 1 ELSE 0 END) / COUNT(*) AS non_breakout_percentage
 FROM trading.prices
 WHERE market_date >= '2019-01-01' AND market_date <= '2019-12-31'
 GROUP BY ticker;


### PR DESCRIPTION
- Proposed correction for the query in Question 6 where it asked for average of the price column for **Ethereum** in 2020 but the answer's query averaged all entries without filtering `ticker = 'ETH'`.
- Syntax typo correction in Appendix (Integer Floor Division)